### PR TITLE
Fix overwrite in merge for multiple MapReduce responses.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@ function _merge(obj1, obj2) {
     var obj = {};
     if (obj2.hasOwnProperty('phase')) {
         obj = obj1;
-        obj[obj2.phase] = JSON.parse(obj2.response);
+        if (obj[obj2.phase] === undefined) obj[obj2.phase] = [];
+        obj[obj2.phase] = obj[obj2.phase].concat(JSON.parse(obj2.response));
     } else {
         [obj1, obj2].forEach(function (old) {
             Object.keys(old).forEach(function (key) {


### PR DESCRIPTION
Merge would silently overwrite previous results from the same MapReduce phase. This seems to have come up when there were multiple response arriving subsequently for the same phase.
