### PR TITLE
Support for large messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,20 +51,37 @@ function RiakPBC(options) {
     self.client.on('error', self.disconnect);
     self.paused = false;
     self.queue = [];
-    var mc, reply = {};
+    var mc, reply = {}, resBuffers = [], numBytesAwaiting = 0;
 
     function splitPacket(pkt) {
-        var ret = [], len, pos = 0, end = pkt.length;
+        var pos = 0, len;
+        if (numBytesAwaiting > 0) {
+            len = Math.min(pkt.length, numBytesAwaiting);
+            var oldBuf = resBuffers[resBuffers.length - 1];
+            var newBuf = new Buffer(oldBuf.length + len);
+            oldBuf.copy(newBuf, 0);
+            pkt.slice(0, len).copy(newBuf, oldBuf.length);
+            resBuffers[resBuffers.length - 1] = newBuf;
+            pos = len;
+            numBytesAwaiting -= len;
+        } else {
+            resBuffers = [];
+        }
+        var end = pkt.length;
         while (pos < end) {
             len = butils.readInt32(pkt, pos);
-            ret.push(pkt.slice(pos + 4, pos + len + 4));
+            numBytesAwaiting = len + 4 - pkt.length;
+            resBuffers.push(pkt.slice(pos + 4, Math.min(pos + len + 4, pkt.length)));
             pos += len + 4;
         }
-        return ret;
     }
 
     self.client.on('data', function (chunk) {
-        splitPacket(chunk).forEach(function (packet) {
+        splitPacket(chunk);
+        if (numBytesAwaiting > 0) {
+            return;
+        }
+        resBuffers.forEach(function (packet) {
             mc = messageCodes['' + packet[0]];
             reply = _merge(reply, self.translator.decode(mc, packet.slice(1)));
             if (!self.task.expectMultiple || reply.done || mc === 'RpbErrorResp') {

--- a/index.js
+++ b/index.js
@@ -67,8 +67,7 @@ function RiakPBC(options) {
         } else {
             resBuffers = [];
         }
-        var end = pkt.length;
-        while (pos < end) {
+        while (pos < pkt.length) {
             len = butils.readInt32(pkt, pos);
             numBytesAwaiting = len + 4 - pkt.length;
             resBuffers.push(pkt.slice(pos + 4, Math.min(pos + len + 4, pkt.length)));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var net = require('net'),
     protobuf = require('protobuf.js'),
-    butils = require('butils');
+    butils = require('butils'),
+	path = require('path');
 
 var messageCodes = {
     '0': 'RpbErrorResp',
@@ -43,7 +44,7 @@ function RiakPBC(options) {
     self.host = options.host || '127.0.0.1';
     self.port = options.port || 8087;
     self.bucket = options.bucket || undefined;
-    self.translator = protobuf.loadSchema('./spec/riak_kv.proto');
+    self.translator = protobuf.loadSchema(path.join(__dirname, './spec/riak_kv.proto'));
     self.client = new net.Socket();
     self.connected = false;
     self.client.on('end', self.disconnect);

--- a/test/spec.js
+++ b/test/spec.js
@@ -48,6 +48,31 @@ exports.get = function (test) {
     });
 };
 
+exports.putLarge = function (test) {
+    var value = {};
+    for (var i = 0; i < 5000; i++) {
+        value['test_key_' + i] = 'test_value_' + i;
+    }
+    client.put({ bucket: 'test', key: 'large_test', content: { value: JSON.stringify(value), content_type: 'application/json' }}, function (reply) {
+        test.equal(reply.errmsg, undefined);
+        test.done();
+    });
+};
+
+exports.getLarge = function (test) {
+    var value = {};
+    for (var i = 0; i < 5000; i++) {
+        value['test_key_' + i] = 'test_value_' + i;
+    }
+    client.get({ bucket: 'test', key: 'large_test' }, function (reply) {
+        test.equal(reply.errmsg, undefined);
+        test.ok(Array.isArray(reply.content));
+        test.equal(reply.content.length, 1);
+        test.equal(reply.content[0].value, JSON.stringify(value));
+        test.done();
+    });
+};
+
 exports.getIndex = function (test) {
     client.getIndex({ bucket: 'test', index: 'test_bin', qtype: 0, key: 'test' }, function (reply) {
         test.equal(reply.errmsg, undefined);


### PR DESCRIPTION
When reading large messages (>65k) from Riak, data arrives in chunks and current implementation doesn't work as it assumes the whole message arrives in single client.on('data') event. This adds support for such messages buffering the data until the whole message is read. Also adds tests for large put/get.
