### PR TITLE
Add: test for streaming secondary index query.

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,6 +377,9 @@ RiakPBC.prototype.getIndex = function (params, streaming, callback) {
         streaming = false;
         expectMultiple = false;
     }
+    else {
+        params.stream = true;
+    }
 
     opts = {
         type: 'RpbIndexReq',

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -195,6 +195,33 @@ describe('Client test', function () {
             });
         });
 
+        it('getIndex streaming for binary range', function (done) {
+            var opts = {
+                bucket: bucket,
+                index: binaryIndexKey,
+                qtype: 1,
+                range_min: '!',
+                range_max: '~'
+            };
+            var streaming = true;
+            var readStream = client.getIndex(opts, streaming);
+            var dataHandlerSpy = sinon.spy(dataHandler);
+            readStream.on('data', dataHandlerSpy);
+            readStream.on('end', endHandler);
+
+            function dataHandler(reply) {
+                expect(reply).to.exist;
+                expect(reply).to.have.ownProperty('keys');
+                expect(reply.keys).to.be.an('array');
+                expect(reply.keys[0]).to.equal(keyValue);
+            }
+
+            function endHandler() {
+                expect(dataHandlerSpy.callCount).to.be.above(0);
+                done();
+            }
+        });
+
         it('getIndex for integer range', function (done) {
             var opts = {
                 bucket: bucket,


### PR DESCRIPTION
There is a bug that prevents end from ever getting called on the stream.
The source of this bug is still unclear.

At least now we have a test case that identifies the bug.
