### PR TITLE
Bugfix: emit errors correctly for streaming apis.

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,18 @@ RiakPBC.prototype._processNext = function () {
             self.task = self.queue.shift();
 
             if (err) {
-                return self.task.callback(err);
+                if (self.task.callback) {
+                    self.task.callback(err);
+                    return;
+                }
+                if (self.task.stream) {
+                    self.task.stream.emit('error', err);
+                    return;
+                }
+
+                // unhandled error, throw it
+                throw err;
+
             }
 
             self.client.write(self.task.message);

--- a/test/streaming-error-test.js
+++ b/test/streaming-error-test.js
@@ -1,0 +1,36 @@
+var chai = require('chai');
+chai.Assertion.includeStack = true; // defaults to false
+var expect = chai.expect;
+
+var riakpbc = require('../index');
+
+describe('Streaming error test', function () {
+    it('should output error events when using a streaming api', function (done) {
+        var invalidPort = 1111;
+        var clientOpts = {
+            host: 'localhost',
+            port: invalidPort,
+            timeout: 20 // 20 milliseconds to make test run faster
+        };
+        var client = riakpbc.createClient(clientOpts);
+        var queryOpts = {
+            queryType: 1, // range query type
+            range_min: 0,
+            range_max: 999999,
+            index: 'name_bin',
+            bucket: 'test'
+        };
+        var streaming = true;
+        var readStream = client.getIndex(queryOpts, streaming);
+        readStream.on('error', errorHandler);
+
+        function errorHandler(err) {
+            expect(err).to.exist;
+            expect(err.message).to.equal('Connection timeout');
+            done();
+        }
+
+
+    });
+});
+


### PR DESCRIPTION
Previously errors where only handled for callback based api's. This now emits `error` events correctly when using the streaming api.
