### PR TITLE
make explicit calls to disconnect prevent future auto connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ on a different port:
 var client = riakpbc.createClient({host: 'riak.somewhere-else.com', port: 8086});
 ```
 
+There is also an ```auto_connect``` option to define if the client should automatically
+connect to the Riak server before running any commands. If the ```disconnect``` method
+is called, ```auto_connect``` will be automatically set to ```false``` to prevent
+future connections and all subsequent client calls will result in an error.
 
 ## API
 
@@ -571,6 +575,8 @@ This method has no effect if the client is already connected.
 
 This method disconnects the client from the server.  It takes no parameters and
 returns no value.  If the client is not connected, this method has no effect.
+This method also explicitly sets the ```auto_connect``` option to false to prevent
+the client reconnecting automatically.
 
 ```javascript
 client.disconnect();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riakpbc",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "RiakPBC is a low-level Riak 1.4 proto buffer client.",
   "main": "index.js",
   "dependencies": {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -566,6 +566,15 @@ describe('Client test', function () {
         done();
     });
 
+    it('prevents reconnections', function (done) {
+        client.ping(function (err) {
+            expect(err, 'should error after disconnect').to.exist;
+            // create a new client so it will automatically connect again
+            client = riakpbc.createClient();
+            done();
+        });
+    });
+
     describe('time sensitive', function () {
         var clock;
         before(function () {


### PR DESCRIPTION
this helps mitigate the sometimes unexpected behavior of the client attempting to reconnect even though the user has explicitly called the disconnect method.
