### PR TITLE
Fix parsing empty content values

### DIFF
--- a/lib/parse-response.js
+++ b/lib/parse-response.js
@@ -6,7 +6,7 @@ module.exports = function parseResponse(response) {
     for (key in response) {
         if (Buffer.isBuffer(response[key])) {
             if (key === 'value') {
-                if (response.content_type) {
+                if (response.content_type && response[key].length !== 0) {
                     contentType = getContentType(response);
                     if (contentType === 'application/json') {
                         response[key] = JSON.parse(response[key]);


### PR DESCRIPTION
Content value might be empty when for example 'return_head' option is set with `put` request: http://docs.basho.com/riak/1.4.7/dev/references/protocol-buffers/store-object/
