### PR TITLE
Fix buffer offset error in ConnectionManager._receive + some refactoring

### DIFF
--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -64,24 +64,20 @@ ConnectionManager.prototype.disconnect = function (callback) {
 
 // Write data to the socket
 ConnectionManager.prototype.send = function (data, callback) {
-    function send() {
-        this.client.write(data);
-    }
+    var self = this;
 
-    if (this.auto_connect) {
-        this.connect(function (err) {
+    if (self.auto_connect && !self.connected) {
+        self.connect(function (err) {
             if (err) {
                 return callback(err);
             }
-            send.call(this);
-            callback();
-        }.bind(this));
+            self.client.write(data, callback);
+        });
     } else {
-        if (!this.connected) {
+        if (!self.connected) {
             return callback(new Error('Not connected'));
         }
-        send.call(this);
-        callback();
+        self.client.write(data, callback);
     }
 };
 

--- a/lib/connection-manager.js
+++ b/lib/connection-manager.js
@@ -9,10 +9,8 @@ function ConnectionManager(options) {
 
     // internal state
     this.connected = false;
-    this.remainingBytes = 0;
-    this.buffer = null;
-    this.buffers = [];
-    this.bufferPosition = 0;
+    this.readBuf = new Buffer(256 * 1024);
+    this.readBufPos = 0;
 
     // the actual socket
     this.client = new net.Socket();
@@ -87,45 +85,46 @@ ConnectionManager.prototype.send = function (data, callback) {
     }
 };
 
+ConnectionManager.prototype._growReadBuffer = function (newLength) {
+    var _b = new Buffer(newLength);
+    this.readBuf.copy(_b, 0, 0, this.readBufPos);
+    this.readBuf = _b;
+};
+
 // Got data from the socket. We make sure to split it into the correct
 // sizes and call the client assigned receive function on each chunk
 ConnectionManager.prototype._receive = function (data) {
-    var length, i, l, end;
-    var position = 0;
+    var length;
 
-    if (this.remainingBytes > 0) {
-        end = Math.min(data.length, this.remainingBytes);
-        data.copy(this.buffer, this.bufferPosition, 0, end);
-        this.bufferPosition += end;
-        this.remainingBytes -= end;
-        position += end;
-        if (this.remainingBytes === 0) {
-            this.buffers.push(this.buffer);
-            this.buffer = null;
-            this.bufferPosition = 0;
+    if (this.readBufPos) {
+        if (this.readBuf.length < data.length + this.readBufPos) {
+            this._growReadBuffer(data.length + this.readBufPos);
         }
+        data.copy(this.readBuf, this.readBufPos);
+        this.readBufPos += data.length;
+        data = this.readBuf.slice(0, this.readBufPos);
     }
 
-    while (position < data.length) {
-        length = data.readInt32BE(position);
-        position += 4;
-        this.buffer = new Buffer(length);
-        end = Math.min(length, data.slice(position).length);
-        data.copy(this.buffer, 0, position, position + end);
-        this.bufferPosition = end;
-        this.remainingBytes = length - end;
-        position += end;
-        if (this.remainingBytes === 0) {
-            this.buffers.push(this.buffer);
-            this.buffer = null;
-            this.bufferPosition = 0;
+    length = data.length < 4 ? 0 : data.readInt32BE(0);
+
+    if (data.length < 4 + length) {
+        if (this.readBufPos === 0) {
+            if (this.readBuf.length < 4 + length) {
+                this._growReadBuffer(4 + length);
+            }
+            data.copy(this.readBuf);
+            this.readBufPos += data.length;
         }
+        return;
     }
 
-    for (i = 0, l = this.buffers.length; i < l; i++) {
-        this.receive(this.buffers[i]);
+    this.readBufPos = 0;
+
+    this.receive(data.slice(4, length + 4));
+
+    if (data.length > 4 + length) {
+        this._receive(data.slice(length + 4));
     }
-    this.buffers = [];
 };
 
 module.exports = ConnectionManager;


### PR DESCRIPTION
This PR will:
1. Fix possible buffer offset error at https://github.com/nlf/riakpbc/blob/master/lib/connection-manager.js#L110 (4 bytes will be read even if there is only 1 byte available at the end of the buffer). The error was quite rare but I was able to replicate it on large amounts of data.
2. Refactor `_receive()` to use a single read buffer which results in some performance gains
3. Refactor `send()` to not call `connect()` on each invocation
