### PR TITLE
Riak 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "0.10"
 
 before_install:
+  - "sudo apt-get purge riak"
   - "curl -sO http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.0.0pre11/ubuntu/precise/riak_2.0.0pre11-1_amd64.deb"
   - "sudo dpkg -i riak_2.0.0pre11-1_amd64.deb"
   - 'sudo sed -i.bak -e s/"storage_backend = bitcask"/"storage_backend = leveldb"/g /etc/riak/riak.conf'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ node_js:
   - "0.10"
 
 before_install:
-  - "curl http://apt.basho.com/gpg/basho.apt.key | sudo apt-key add -"
-  - 'sudo bash -c "echo deb http://apt.basho.com $(lsb_release -sc) main > /etc/apt/sources.list.d/basho.list"'
-  - "sudo apt-get update"
-  - "yes n | sudo apt-get install riak --force-yes"
-  - "./bin/enable-riak-search.sh"
+  - "curl -sO http://s3.amazonaws.com/downloads.basho.com/riak/2.0/2.0.0pre11/ubuntu/precise/riak_2.0.0pre11-1_amd64.deb"
+  - "sudo dpkg -i riak_2.0.0pre11-1_amd64.deb"
+  - 'sudo sed -i.bak -e s/"storage_backend = bitcask"/"storage_backend = leveldb"/g /etc/riak/riak.conf'
+  - 'sudo sed -i.bak -e s/"search = off"/"search = on"/g /etc/riak/riak.conf'
   - "sudo service riak start"
+  - "sudo make dt-setup"
 
 before_script:
-  - sudo /usr/sbin/search-cmd install test
-  - sudo /usr/sbin/search-cmd install search_test
+  # - sudo /usr/sbin/search-cmd install test
+  # - sudo /usr/sbin/search-cmd install search_test

--- a/index.js
+++ b/index.js
@@ -325,6 +325,46 @@ RiakPBC.prototype.fetchDtype = function (params, callback) {
     });
 };
 
+RiakPBC.prototype.ykGetIndex = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbYokozunaIndexGetReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.ykPutIndex = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbYokozunaIndexPutReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.ykDeleteIndex = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbYokozunaIndexDeleteReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.ykPutSchema = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbYokozunaSchemaPutReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.ykGetSchema = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbYokozunaSchemaGetReq',
+        params: params,
+        callback: callback
+    });
+};
+
 RiakPBC.prototype.connect = function (callback) {
     this.connection.connect(callback);
 };

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ RiakPBC.prototype.makeRequest = function (opts) {
     message.writeInt32BE(buffer.length + 1, 0);
     message.writeInt8(riakproto.codes[opts.type], 4);
     buffer.copy(message, 5);
-    
+
     this.queue.push({
         message: message,
         callback: opts.callback,
@@ -289,6 +289,38 @@ RiakPBC.prototype.ping = function (callback) {
     return this.makeRequest({
         type: 'RpbPingReq',
         params: null,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.setBucketType = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbSetBucketTypeReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.getBucketType = function (params, callback) {
+    return this.makeRequest({
+        type: 'RpbGetBucketTypeReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.updateDtype = function (params, callback) {
+    return this.makeRequest({
+        type: 'DtUpdateReq',
+        params: params,
+        callback: callback
+    });
+};
+
+RiakPBC.prototype.fetchDtype = function (params, callback) {
+    return this.makeRequest({
+        type: 'DtFetchReq',
+        params: params,
         callback: callback
     });
 };

--- a/makefile
+++ b/makefile
@@ -3,6 +3,10 @@ REPORTER?=spec
 GROWL?=--growl
 FLAGS=$(GROWL) --reporter $(REPORTER) --colors
 
+dt-setup:
+	riak-admin bucket-type create dt-test-set '{"props":{"datatype":"set","allow_mult":"true"}}'
+	riak-admin bucket-type activate dt-test-set
+
 test:
 	$(MOCHA) $(shell find test -name "*-test.js") $(FLAGS)
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "protobuf.js": "~1.1.0",
-    "riakproto": "~1.4.7"
+    "riakproto": "git://github.com/nlf/riakproto#riak2"
   },
   "devDependencies": {
     "nodeunit": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "protobuf.js": "~1.1.0",
-    "riakproto": "git://github.com/nlf/riakproto#riak2"
+    "riakproto": "~=2.0.0-preview"
   },
   "devDependencies": {
     "nodeunit": "",

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -470,7 +470,7 @@ describe('Client test', function () {
 
     it('counters', function (done) {
         var currentValue = 3;
-        var bucket = 'test';
+        var bucket = 'test-' + Date.now();
         var key = 'counter';
         savedKeys[key] = bucket;
         var setOpts = {
@@ -479,8 +479,8 @@ describe('Client test', function () {
             amount: currentValue
         };
         var getOpts = {
-            bucket: 'test',
-            key: 'counter'
+            bucket: bucket,
+            key: key
         };
         var promise;
         try {
@@ -533,7 +533,7 @@ describe('Client test', function () {
                 bucket: 'test'
             }, function (err, reply) {
                 expect(reply).to.exist;
-                expect(reply.props.allow_mult).to.be.false;
+                expect(reply.props.allow_mult).to.be.true; // allow_mult=true is default in riak 2.0
                 done();
             });
         });

--- a/test/dt-test.js
+++ b/test/dt-test.js
@@ -27,6 +27,9 @@ describe('DataTypes', function () {
                     }
                 }
             }, function (err, reply) {
+                if (err && err.message.indexOf('Error no bucket type') !== -1) {
+                    throw new Error('Please run "make dt-setup" before running tests');
+                }
                 expect(err).to.not.exist;
                 expect(reply.set_value).to.exist;
                 expect(reply.set_value).to.contain('someSetValue');

--- a/test/dt-test.js
+++ b/test/dt-test.js
@@ -1,0 +1,70 @@
+var chai = require('chai');
+chai.Assertion.includeStack = true; // defaults to false
+var expect = chai.expect;
+
+var riakpbc = require('../index');
+var client = riakpbc.createClient({ host: 'localhost', port: 8087 });
+
+/**
+ * make sure to do run `make dt-setup` to create required bucket types
+ */
+
+var bucket = 'dt-test-bucket', bucketType = 'dt-test-set';
+
+describe('DataTypes', function () {
+
+    describe('set', function () {
+
+        it('#updateDtype - add value', function (done) {
+            client.updateDtype({
+                bucket: bucket,
+                key: 'test',
+                type: bucketType,
+                return_body: true,
+                op: {
+                    set_op: {
+                        adds: 'someSetValue'
+                    }
+                }
+            }, function (err, reply) {
+                expect(err).to.not.exist;
+                expect(reply.set_value).to.exist;
+                expect(reply.set_value).to.contain('someSetValue');
+                done();
+            });
+        });
+
+        it('#fetchDtype - get value', function (done) {
+            client.fetchDtype({
+                bucket: bucket,
+                key: 'test',
+                type: bucketType
+            }, function (err, reply) {
+                expect(err).to.not.exist;
+                expect(reply.value.set_value).to.exist;
+                expect(reply.value.set_value).to.contain('someSetValue');
+                done();
+            });
+        });
+
+        it('#updateDtype - remove value', function (done) {
+            client.updateDtype({
+                bucket: bucket,
+                key: 'test',
+                type: bucketType,
+                return_body: true,
+                op: {
+                    set_op: {
+                        removes: 'someSetValue'
+                    }
+                }
+            }, function (err, reply) {
+                expect(err).to.not.exist;
+                expect(reply.set_value).to.not.exist;
+                done();
+            });
+        });
+
+    });
+
+});

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -12,7 +12,7 @@ var client = riakpbc.createClient({ host: 'localhost', port: 8087 });
 
 var numRows = 10;
 var bucket = 'search_test';
-describe('search', function searchSuite() {
+describe.skip('search', function searchSuite() {
     this.slow('1s');
     before(function beforeBlock(done) {
         var promise = connectClient();

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -67,7 +67,7 @@ describe('Search', function () {
                 expect(reply.index[0]).to.be.have.property('schema', schema.name);
                 done();
             });
-        }, 1000); // wait for solr to create its index
+        }, 3000); // wait for solr to create its index
     });
 
     describe('search for docs', function () {

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -1,77 +1,121 @@
-var _ = require('lodash-node');
 var chai = require('chai');
 chai.Assertion.includeStack = true; // defaults to false
-
 var expect = chai.expect;
-var inspect = require('eyespect').inspector();
 var q = require('q');
-var sinon = require('sinon');
+var _ = require('lodash-node');
 
-var riakpbc = require('../index');
-var client = riakpbc.createClient({ host: 'localhost', port: 8087 });
+var client = require('../index').createClient({ host: 'localhost', port: 8087 });
 
-var numRows = 10;
-var bucket = 'search_test';
-describe.skip('search', function searchSuite() {
-    this.slow('1s');
-    before(function beforeBlock(done) {
-        var promise = connectClient();
-        promise.then(setupFixtures).nodeify(done);
-    });
+var bucket = 'test-search-bucket-' + Date.now();
+var index = 'test-search-index-' + Date.now();
+var schema = {
+    name: 'test-search-schema-' + Date.now(),
+    content: require('fs').readFileSync(require('path').resolve(__dirname, './yk-test-schema.xml'))
+};
 
-    after(function afterBlock(done) {
-        this.timeout('10s');
-        return done();
-    });
+describe('Search', function () {
 
-    it('should return search results', function (done) {
-        var opts = {
-            q: 'bar:value_*',
-            index: bucket,
-            rows: 1,
-            start: 0
-        };
-        client.search(opts, cb);
-
-        function cb(err, reply) {
+    it('create schema', function (done) {
+        client.ykPutSchema({
+            schema: {
+                name: schema.name,
+                content: schema.content
+            }
+        }, function (err) {
             expect(err).to.not.exist;
-            expect(reply, 'should get search reply').to.exist;
-            expect(reply).to.have.ownProperty('docs');
-            expect(reply).to.have.ownProperty('max_score');
-            expect(reply.docs).to.be.an('array');
-            expect(reply.docs.length).to.equal(opts.rows);
-            expect(reply, 'num_found field missing in reply').to.have.ownProperty('num_found');
-            expect(reply.num_found).to.be.above(opts.rows);
             done();
-        }
+        });
     });
+
+    it('get schema', function (done) {
+        client.ykGetSchema({
+            name: schema.name,
+        }, function (err, reply) {
+            expect(err).to.not.exist;
+            expect(reply).to.be.an('object');
+            expect(reply).to.have.property('schema');
+            expect(reply.schema).to.have.property('name', schema.name);
+            expect(reply.schema).to.have.property('content', schema.content.toString());
+            done();
+        });
+    });
+
+    it('create index', function (done) {
+        this.timeout(5000); // creating index may take some time
+        client.ykPutIndex({
+            index: {
+                name: index,
+                schema: schema.name
+            }
+        }, function (err) {
+            expect(err).to.not.exist;
+            done();
+        });
+    });
+
+    it('get index', function (done) {
+        this.timeout(5000);
+        setTimeout(function () {
+            client.ykGetIndex({
+                name: index,
+            }, function (err, reply) {
+                expect(err).to.not.exist;
+                expect(reply).to.be.an('object');
+                expect(reply).to.have.property('index').that.is.an('array').and.have.length(1);
+                expect(reply.index[0]).to.be.an('object');
+                expect(reply.index[0]).to.be.have.property('name', index);
+                expect(reply.index[0]).to.be.have.property('schema', schema.name);
+                done();
+            });
+        }, 1000); // wait for solr to create its index
+    });
+
+    describe('search for docs', function () {
+        before(function (done) {
+            client.setBucket({
+                bucket: bucket,
+                props: {
+                    search_index: index
+                }
+            }, function (err) {
+                expect(err).to.not.exist;
+
+                q.all(_.map(['abc 123', 'def 456', 'abc def 123 456'], function (text, ind) {
+                    return q.ninvoke(client, 'put', {
+                        bucket: bucket,
+                        key: 'key' + ind,
+                        content: {
+                            value: JSON.stringify({
+                                title: 'test',
+                                text: text
+                            }),
+                            content_type: 'application/json'
+                        }
+                    });
+                }))
+                .then(function () { return q.delay(1000); }) // wait for docs to index
+                .nodeify(done);
+            });
+        });
+
+        it('should return docs', function (done) {
+            client.search({
+                q: 'text:abc AND title:test',
+                index: index
+            }, function (err, reply) {
+                expect(err).to.not.exist;
+                expect(reply).to.be.an('object');
+                expect(reply).to.have.property('docs').that.is.an('array').and.have.length(2);
+                expect(reply).to.have.property('num_found', 2);
+                var keys = _.map(reply.docs, function (doc) {
+                    return _.find(doc.fields, {key: '_yz_rk'}).value;
+                });
+                expect(keys).to.contain('key0');
+                expect(keys).to.contain('key2');
+                done();
+            });
+        });
+    });
+
 });
 
-function connectClient() {
-    var promise = q.ninvoke(client, 'connect');
-    return promise;
-}
-
-function setupFixtures() {
-    var promises = _.range(0, numRows).map(createRow);
-    return q.all(promises);
-}
-
-function createRow(id) {
-    var key = [id, 'key'].join('_');
-    var value = {
-        bar: 'value_' + id
-    };
-    var content = {
-        value: JSON.stringify(value),
-        content_type: 'application/json'
-    };
-    var saveOpts = {
-        bucket: bucket,
-        content: content,
-        key: key
-    };
-
-    var promise = q.ninvoke(client, 'put', saveOpts);
-    return promise;
-}

--- a/test/yk-test-schema.xml
+++ b/test/yk-test-schema.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema name="test" version="1.5">
+  <fields>
+    <field name="title" type="text_ws" indexed="true" stored="true"/>
+    <field name="text" type="text_ws" indexed="true" stored="true"/>
+
+    <!-- Needed by Yokozuna -->
+    <field name="_yz_id" type="_yz_str" indexed="true" stored="true" required="true" />
+    <field name="_version_" type="long" indexed="true" stored="true"/>
+    <field name="_yz_ed" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_pn" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_fpn" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_vtag" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_node" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_rb" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_rk" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_rt" type="_yz_str" indexed="true" stored="true"/>
+    <field name="_yz_err" type="_yz_str" indexed="true"/>
+  </fields>
+
+  <uniqueKey>_yz_id</uniqueKey>
+
+  <types>
+    <fieldType name="_yz_str" class="solr.StrField" sortMissingLast="true" />
+    <!-- <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/> -->
+    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
+
+    <!-- A text field that only splits on whitespace for exact matching of words -->
+    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
+  </types>
+</schema>


### PR DESCRIPTION
This PR is to get started with Riak 2.0 support:
1. It adds `updateDtype` and `fetchDtype` methods common for all CRDTs in Riak 2.0.

More information on CRDTs in Riak available here:
https://gist.github.com/russelldb/7316f83ddd38965d9f76
https://github.com/basho/riak/issues/354
1. Updates Travis build to use Riak 2.0 (2.0.0pre11 at this moment)
2. Yokozuna support yet to come so search tests are disabled

Make sure you run `make dt-setup` before running tests. This is because at present you can only manually create and activate new bucket types: https://github.com/basho/riak/issues/484
