### PR TITLE
convert numeric const quorum values to strings and vice versa

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var Stream = require('stream');
 var Protobuf = require('protobuf.js');
 var riakproto = require('riakproto');
 var _merge = require('./lib/merge');
+var quorum = require('./lib/quorum');
 var parseResponse = require('./lib/parse-response');
 var ConnectionManager = require('./lib/connection-manager');
 
@@ -147,6 +148,10 @@ RiakPBC.prototype.getBucket = function (params, callback) {
 };
 
 RiakPBC.prototype.setBucket = function (params, callback) {
+    if (params.props) {
+        params.props = quorum.convert(params.props);
+    }
+
     return this.makeRequest({
         type: 'RpbSetBucketReq',
         params: params,

--- a/lib/parse-response.js
+++ b/lib/parse-response.js
@@ -1,7 +1,10 @@
+var quorum = require('./quorum');
 var textPattern = /^text\/*/;
 
 module.exports = function parseResponse(response) {
     var key, contentType;
+
+    response = quorum.convert(response);
 
     for (key in response) {
         if (Buffer.isBuffer(response[key])) {

--- a/lib/quorum.js
+++ b/lib/quorum.js
@@ -1,0 +1,21 @@
+var quorums = ['pr', 'r', 'w', 'pw', 'dw', 'rw'];
+var quorumMap = {
+    '4294967294': 'one',
+    one: 4294967294,
+    '4294967293': 'quorum',
+    quorum: 4294967293,
+    '4294967292': 'all',
+    all: 4294967292,
+    '4294967291': 'default',
+    default: 4294967291
+};
+
+exports.convert = function (props) {
+    Object.keys(props).forEach(function (key) {
+        if (~quorums.indexOf(key) && quorumMap[props[key]]) {
+            props[key] = quorumMap[props[key]];
+        }
+    });
+
+    return props;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riakpbc",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "RiakPBC is a low-level Riak 1.4 proto buffer client.",
   "main": "index.js",
   "dependencies": {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -342,6 +342,29 @@ describe('Client test', function () {
         });
     });
 
+    it('setBucket converts quorum values', function (done) {
+        var opts = {
+            bucket: 'test',
+            props: {
+                r: 'quorum',
+                w: 'all'
+            }
+        };
+        client.setBucket(opts, function (err, reply) {
+            expect(err).to.not.exist;
+            done();
+        });
+    });
+
+    it('getBucket converts quorum values', function (done) {
+        client.getBucket({ bucket: 'test' }, function (err, reply) {
+            expect(err).to.not.exist;
+            expect(reply.props.r).to.equal('quorum');
+            expect(reply.props.w).to.equal('all');
+            done();
+        });
+    });
+
     it('getKeys', function (done) {
         client.getKeys({
             bucket: 'test'


### PR DESCRIPTION
This makes sure the numerical constants are converted to strings like 'quorum', 'default', 'all', and 'one' for values in bucket properties. Also converts string values to their numerical counterparts when calling `setBucket`
