### PR TITLE
Force cleanup before destroying socket

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -68,6 +68,9 @@ ConnectionManager.prototype.connect = function (callback) {
 // Public disconnect method
 ConnectionManager.prototype.disconnect = function () {
 
+    if (this.task && this.task.callback) {
+        this._cleanup(new Error('Connection destroyed'));
+    }
     // destroy the socket, this invalidates it for the connection pool
     this.client.destroy();
 };


### PR DESCRIPTION
I noticed that we were occasionally not seeing callbacks fire for reads. I then found that there was a 1:1 correlation between occasions where disconnect executed and `this.task` was non-null and occasions where we saw no callback for a read.

This patch seems to have fixed it for us.

Thanks for the library!
