### PR TITLE
Maxlife

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The `options` object accepts the following parameters:
 
 - `connectTimeout`: The timeout (in milliseconds) for creating a new connection. (Default: `1000`)
 - `idleTimeout`: The amount of time (in milliseconds) that a node can be idle in the connection pool before it is released. (Default: `30000`)
+- `maxLifetime`: The amount of time (in milliseconds) that a node is used in the connection pool before it is released, regardless of activity. (Default: `Infinity`)
 - `minConnections`: The minimum number of connections to keep active in the connection pool. (Default: `0`)
 - `maxConnections`: The maximum number of connections that may be active in the connection pool at any given time. (Default: `10`)
 - `parseValues`: If set to `false`, values will be returned as buffers rather than strings or parsed JSON. (Default: `true`)

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ function RiakPBC(options) {
 
                     callback(err, client);
                 });
+
+                client.createdAt = Date.now();
             },
             destroy: function (client) {
 
@@ -31,7 +33,9 @@ function RiakPBC(options) {
             },
             validate: function (client) {
 
-                return !client.client.destroyed;
+                var expired = ((Date.now() - client.createdAt) >= options.maxLifetime);
+
+                return !expired && !client.client.destroyed;
             }
         });
     });

--- a/lib/options.js
+++ b/lib/options.js
@@ -13,6 +13,7 @@ var schema = Joi.object().keys({
     }).and('user', 'password'),
     connectTimeout: Joi.number().default(1000),
     idleTimeout: Joi.number().default(30000),
+    maxLifetime: Joi.number().default(Infinity),
     minConnections: Joi.number().default(0),
     maxConnections: Joi.number().default(10),
     parseValues: Joi.boolean().default(true)

--- a/test/options.js
+++ b/test/options.js
@@ -19,6 +19,7 @@ describe('Options', function () {
                 nodes: [{ host: '127.0.0.1', port: 8087 }],
                 connectTimeout: 1000,
                 idleTimeout: 30000,
+                maxLifetime: Infinity,
                 minConnections: 0,
                 maxConnections: 10,
                 parseValues: true
@@ -37,6 +38,7 @@ describe('Options', function () {
                 nodes: [{ host: '127.0.0.1', port: 8087 }],
                 connectTimeout: 1000,
                 idleTimeout: 30000,
+                maxLifetime: Infinity,
                 minConnections: 0,
                 maxConnections: 10,
                 parseValues: true


### PR DESCRIPTION
Add support for enforcing a connection's maximum life, regardless of connectivity. This is useful in situations where Riak is behind a load balancer that kills long lived connections periodically as a mean to detect and adapt to topology changes.
